### PR TITLE
Merge Version 0.2

### DIFF
--- a/TobysBot.Discord.Audio/Extensions/LavaNodeExtensions.cs
+++ b/TobysBot.Discord.Audio/Extensions/LavaNodeExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Victoria;
+using Victoria.Responses.Search;
+
+namespace TobysBot.Discord.Audio.Extensions;
+
+public static class LavaNodeExtensions
+{
+    public static async Task<LavaTrack> LoadTrackAsync(this LavaNode node, ITrack track)
+    {
+        var search = await node.SearchAsync(SearchType.Direct, track.Url);
+
+        if (search.Status != SearchStatus.TrackLoaded)
+        {
+            throw new Exception(search.Exception.Message);
+        }
+
+        return search.Tracks.First();
+    }
+}

--- a/TobysBot.Discord.Audio/GeniusLyricsProvider.cs
+++ b/TobysBot.Discord.Audio/GeniusLyricsProvider.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using TobysBot.Discord.Audio.Extensions;
+using Victoria;
+
+namespace TobysBot.Discord.Audio;
+
+public class GeniusLyricsProvider : ILyricsProvider
+{
+    private readonly LavaNode _node;
+
+    public GeniusLyricsProvider(LavaNode node)
+    {
+        _node = node;
+    }
+    
+    public async Task<string> GetLyricsAsync(ITrack track)
+    {
+        var lavaTrack = await _node.LoadTrackAsync(track);
+
+        return await lavaTrack.FetchLyricsFromGeniusAsync();
+    }
+}

--- a/TobysBot.Discord.Audio/IAudioNode.cs
+++ b/TobysBot.Discord.Audio/IAudioNode.cs
@@ -106,5 +106,20 @@ namespace TobysBot.Discord.Audio
         Task<IQueueStatus> GetQueueAsync(IGuild guild);
 
         Task SetLoopAsync(IGuild guild, LoopSetting setting);
+
+        /// <summary>
+        /// Enables shuffle mode for the queue.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="setting"></param>
+        /// <returns></returns>
+        Task SetShuffleAsync(IGuild guild, ShuffleSetting setting);
+
+        /// <summary>
+        /// Performs a one-time shuffle on the queue.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <returns></returns>
+        Task ShuffleAsync(IGuild guild);
     }
 }

--- a/TobysBot.Discord.Audio/IAudioNode.cs
+++ b/TobysBot.Discord.Audio/IAudioNode.cs
@@ -57,7 +57,7 @@ namespace TobysBot.Discord.Audio
         /// </summary>
         /// <param name="guild"></param>
         /// <returns></returns>
-        Task<ITrack> SkipAsync(IGuild guild);
+        Task<ITrack> SkipAsync(IGuild guild, int index = 0);
 
         /// <summary>
         /// Clears the queue and stops player in the specified guild.

--- a/TobysBot.Discord.Audio/IAudioNode.cs
+++ b/TobysBot.Discord.Audio/IAudioNode.cs
@@ -48,7 +48,14 @@ namespace TobysBot.Discord.Audio
         /// <param name="guild">Guild in which to resume player.</param>
         /// <returns></returns>
         Task ResumeAsync(IGuild guild);
-        
+
+        /// <summary>
+        /// Moves the player to the specified timespan.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="timeSpan"></param>
+        /// <returns></returns>
+        Task SeekAsync(IGuild guild, TimeSpan timeSpan);
 
         // Queue
 

--- a/TobysBot.Discord.Audio/ILyricsProvider.cs
+++ b/TobysBot.Discord.Audio/ILyricsProvider.cs
@@ -1,0 +1,8 @@
+using System.Threading.Tasks;
+
+namespace TobysBot.Discord.Audio;
+
+public interface ILyricsProvider
+{
+    Task<string> GetLyricsAsync(ITrack track);
+}

--- a/TobysBot.Discord.Audio/IQueue.cs
+++ b/TobysBot.Discord.Audio/IQueue.cs
@@ -28,7 +28,7 @@ namespace TobysBot.Discord.Audio
         /// </summary>
         /// <param name="guild"></param>
         /// <returns></returns>
-        Task<ITrack> AdvanceAsync(IGuild guild);
+        Task<ITrack> AdvanceAsync(IGuild guild, int index = 0);
 
         /// <summary>
         /// Returns the next track in the queue without advancing.

--- a/TobysBot.Discord.Audio/IQueue.cs
+++ b/TobysBot.Discord.Audio/IQueue.cs
@@ -31,13 +31,6 @@ namespace TobysBot.Discord.Audio
         Task<ITrack> AdvanceAsync(IGuild guild, int index = 0);
 
         /// <summary>
-        /// Returns the next track in the queue without advancing.
-        /// </summary>
-        /// <param name="guild"></param>
-        /// <returns></returns>
-        Task<ITrack> PeekAsync(IGuild guild);
-
-        /// <summary>
         /// Clears the queue for the specified guild.
         /// </summary>
         /// <param name="guild"></param>

--- a/TobysBot.Discord.Audio/IQueue.cs
+++ b/TobysBot.Discord.Audio/IQueue.cs
@@ -45,5 +45,9 @@ namespace TobysBot.Discord.Audio
         Task ResetAsync(IGuild guild);
 
         Task SetLoopAsync(IGuild guild, LoopSetting setting);
+
+        Task SetShuffleAsync(IGuild guild, ShuffleSetting setting);
+
+        Task ShuffleAsync(IGuild guild);
     }
 }

--- a/TobysBot.Discord.Audio/IQueueStatus.cs
+++ b/TobysBot.Discord.Audio/IQueueStatus.cs
@@ -11,5 +11,7 @@ namespace TobysBot.Discord.Audio
         ITrack CurrentTrack { get; }
         
         LoopSetting LoopEnabled { get; }
+        
+        ShuffleSetting ShuffleEnabled { get; }
     }
 }

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
@@ -188,6 +188,20 @@ namespace TobysBot.Discord.Audio.Lavalink
             
         }
 
+        public async Task SeekAsync(IGuild guild, TimeSpan timeSpan)
+        {
+            LavaPlayer player = ThrowIfNoPlayer(guild);
+
+            try
+            {
+                await player.SeekAsync(timeSpan);
+            }
+            catch
+            {
+                throw;
+            }
+        }
+
         public async Task<ITrack> SkipAsync(IGuild guild, int index = 0)
         {
             LavaPlayer player = ThrowIfNoPlayer(guild);

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TobysBot.Discord.Audio.Extensions;
 using Victoria;
 using Victoria.Enums;
 using Victoria.EventArgs;
@@ -38,7 +39,7 @@ namespace TobysBot.Discord.Audio.Lavalink
 
             var queue = await GetQueueAsync(arg.Player.VoiceChannel.Guild);
             
-            await arg.Player.PlayAsync(await LoadTrackAsync(queue.CurrentTrack));
+            await arg.Player.PlayAsync(await _node.LoadTrackAsync(queue.CurrentTrack));
         }
 
         private async Task NodeOnTrackEnded(TrackEndedEventArgs arg)
@@ -55,7 +56,7 @@ namespace TobysBot.Discord.Audio.Lavalink
                 return;
             }
 
-            await arg.Player.PlayAsync(await LoadTrackAsync(track));
+            await arg.Player.PlayAsync(await _node.LoadTrackAsync(track));
         }
 
         private LavaPlayer ThrowIfNoPlayer(IGuild guild)
@@ -66,18 +67,6 @@ namespace TobysBot.Discord.Audio.Lavalink
             }
 
             return player;
-        }
-
-        private async Task<LavaTrack> LoadTrackAsync(ITrack track)
-        {
-            SearchResponse search = await _node.SearchAsync(SearchType.Direct, track.Url);
-
-            if (search.Status != SearchStatus.TrackLoaded)
-            {
-                throw new Exception(search.Exception.Message);
-            }
-
-            return search.Tracks.First();
         }
 
         public async Task JoinAsync(IVoiceChannel channel, ITextChannel textChannel = null)
@@ -183,7 +172,7 @@ namespace TobysBot.Discord.Audio.Lavalink
                     return;
                 }
                 
-                await player.PlayAsync(await LoadTrackAsync(track));
+                await player.PlayAsync(await _node.LoadTrackAsync(track));
             }
             
         }
@@ -221,7 +210,7 @@ namespace TobysBot.Discord.Audio.Lavalink
             }
             else
             {
-                await player.PlayAsync(await LoadTrackAsync(nextTrack));
+                await player.PlayAsync(await _node.LoadTrackAsync(nextTrack));
             }
             
             return nextTrack;

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
@@ -188,7 +188,7 @@ namespace TobysBot.Discord.Audio.Lavalink
             
         }
 
-        public async Task<ITrack> SkipAsync(IGuild guild)
+        public async Task<ITrack> SkipAsync(IGuild guild, int index = 0)
         {
             LavaPlayer player = ThrowIfNoPlayer(guild);
 
@@ -199,7 +199,7 @@ namespace TobysBot.Discord.Audio.Lavalink
                 await SetLoopAsync(guild, new DisabledLoopSetting());
             }
 
-            ITrack nextTrack = await _queue.AdvanceAsync(guild);
+            ITrack nextTrack = await _queue.AdvanceAsync(guild, index);
 
             if (nextTrack is null)
             {

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
@@ -297,5 +297,15 @@ namespace TobysBot.Discord.Audio.Lavalink
         {
             return _queue.SetLoopAsync(guild, setting);
         }
+
+        public Task SetShuffleAsync(IGuild guild, ShuffleSetting setting)
+        {
+            return _queue.SetShuffleAsync(guild, setting);
+        }
+
+        public Task ShuffleAsync(IGuild guild)
+        {
+            return _queue.ShuffleAsync(guild);
+        }
     }
 }

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioSource.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioSource.cs
@@ -25,7 +25,7 @@ namespace TobysBot.Discord.Audio.Lavalink
             {
                 SearchStatus.SearchResult => new LavalinkTrack(result.Tracks.FirstOrDefault()),
                 SearchStatus.TrackLoaded => new LavalinkTrack(result.Tracks.FirstOrDefault()),
-                SearchStatus.PlaylistLoaded => new LavalinkPlaylist(result.Tracks, query, result.Playlist.Name,
+                SearchStatus.PlaylistLoaded => new LavalinkPlaylist(result.Tracks.Take(25), query, result.Playlist.Name,
                     result.Playlist.SelectedTrack),
                 SearchStatus.NoMatches => null,
                 SearchStatus.LoadFailed => throw new Exception(result.Exception.Message),

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -72,5 +72,17 @@ namespace TobysBot.Discord.Audio.MemoryQueue
 
             return Task.CompletedTask;
         }
+
+        public Task SetShuffleAsync(IGuild guild, ShuffleSetting setting)
+        {
+            if (!_queue.TryGetValue(guild, out var queue))
+            {
+                return Task.CompletedTask;
+            }
+
+            queue.ShuffleEnabled = setting;
+            
+            return Task.CompletedTask;
+        }
     }
 }

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -32,14 +32,14 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             return Task.FromResult<IQueueStatus>(queue);
         }
 
-        public Task<ITrack> AdvanceAsync(IGuild guild)
+        public Task<ITrack> AdvanceAsync(IGuild guild, int index = 0)
         {
             if (!_queue.TryGetValue(guild, out var queue))
             {
                 return null;
             }
             
-            return Task.FromResult<ITrack>(queue.Advance());
+            return Task.FromResult<ITrack>(queue.Advance(index-1));
         }
 
         public Task<ITrack> PeekAsync(IGuild guild)

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -84,5 +84,17 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             
             return Task.CompletedTask;
         }
+
+        public Task ShuffleAsync(IGuild guild)
+        {
+            if (!_queue.TryGetValue(guild, out var queue))
+            {
+                return Task.CompletedTask;
+            }
+            
+            queue.Shuffle();
+            
+            return Task.CompletedTask;
+        }
     }
 }

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -7,7 +7,7 @@ namespace TobysBot.Discord.Audio.MemoryQueue
 {
     public class MemoryQueue : IQueue
     {
-        private readonly Dictionary<IGuild, MemoryTrackCollection> _queue = new Dictionary<IGuild, MemoryTrackCollection>();
+        private readonly Dictionary<IGuild, MemoryTrackCollection> _queue = new();
 
         public Task EnqueueAsync(IGuild guild, IEnumerable<ITrack> tracks, bool advanceToTracks = false)
         {
@@ -40,16 +40,6 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             }
             
             return Task.FromResult<ITrack>(queue.Advance(index-1));
-        }
-
-        public Task<ITrack> PeekAsync(IGuild guild)
-        {
-            if (!_queue.TryGetValue(guild, out var queue))
-            {
-                return null;
-            }
-            
-            return Task.FromResult<ITrack>(queue.NextTrack);
         }
 
         public Task ClearAsync(IGuild guild)

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -7,8 +7,9 @@ namespace TobysBot.Discord.Audio.MemoryQueue
 {
     public class MemoryTrackCollection : IQueueStatus
     {
+        private readonly Random _rng = new();
+        
         private List<MemoryTrack> _tracks => _played.Append(_currentTrack).Concat(_queue).ToList();
-
         private List<MemoryTrack> _played = new();
         private List<MemoryTrack> _queue = new();
         private MemoryTrack _currentTrack;
@@ -40,7 +41,7 @@ namespace TobysBot.Discord.Audio.MemoryQueue
                 
                 var previous = _tracks.Take(index);
                 var current = _tracks[index];
-                var next = _tracks.Skip(index);
+                var next = _tracks.Skip(index + 1);
 
                 _played = previous.ToList();
                 _currentTrack = current;
@@ -62,6 +63,8 @@ namespace TobysBot.Discord.Audio.MemoryQueue
                     
                     _queue.AddRange(_played.Skip(1));
 
+                    _played.Clear();
+                    
                     return _currentTrack;
                 }
                 
@@ -72,9 +75,7 @@ namespace TobysBot.Discord.Audio.MemoryQueue
 
             if (ShuffleEnabled is EnabledShuffleSetting)
             {
-                Random rng = new();
-
-                int element = rng.Next(0, _queue.Count);
+                int element = _rng.Next(0, _queue.Count);
                 _played.Add(_currentTrack);
                 _currentTrack = _queue[element];
                 _queue.RemoveAt(element);
@@ -119,11 +120,10 @@ namespace TobysBot.Discord.Audio.MemoryQueue
         public void Shuffle()
         {
             int n = _queue.Count;
-            Random rng = new();
             
             while (n > 1) {  
                 n--;  
-                int k = rng.Next(n + 1);
+                int k = _rng.Next(n + 1);
                 (_queue[k], _queue[n]) = (_queue[n], _queue[k]);
             }
         }

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -46,9 +47,21 @@ namespace TobysBot.Discord.Audio.MemoryQueue
         
         public ITrack NextTrack => NextIndex() >= _tracks.Count ? null : _tracks[NextIndex()];
 
-        public ITrack Advance()
+        public ITrack Advance(int index)
         {
-            _currentIndex = NextIndex();
+            if (index == -1)
+            {
+                _currentIndex = NextIndex();
+            }
+            else if (index >= _tracks.Count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index),
+                    "Index cannot be larger than the size of the queue.");
+            }
+            else
+            {
+                _currentIndex = index;
+            }
             
             if (_currentIndex >= _tracks.Count)
             {

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -27,6 +27,8 @@ namespace TobysBot.Discord.Audio.MemoryQueue
 
         public LoopSetting LoopEnabled { get; set; } = new DisabledLoopSetting();
 
+        public ShuffleSetting ShuffleEnabled { get; set; } = new DisabledShuffleSetting();
+
         public ITrack Advance(int index)
         {
             if (index != -1)
@@ -67,6 +69,18 @@ namespace TobysBot.Discord.Audio.MemoryQueue
                 _currentTrack = null;
                 return null;
             }
+
+            if (ShuffleEnabled is EnabledShuffleSetting)
+            {
+                Random rng = new();
+
+                int element = rng.Next(0, _queue.Count);
+                _played.Add(_currentTrack);
+                _currentTrack = _queue[element];
+                _queue.RemoveAt(element);
+
+                return _currentTrack;
+            }
             
             _played.Add(_currentTrack);
             _currentTrack = _queue.First();
@@ -100,6 +114,18 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             _queue = _tracks;
             _currentTrack = _queue.First();
             _queue.RemoveAt(0);
+        }
+
+        public void Shuffle()
+        {
+            int n = _queue.Count;
+            Random rng = new();
+            
+            while (n > 1) {  
+                n--;  
+                int k = rng.Next(n + 1);
+                (_queue[k], _queue[n]) = (_queue[n], _queue[k]);
+            }
         }
         
         public IEnumerator<ITrack> GetEnumerator()

--- a/TobysBot.Discord.Audio/ShuffleSetting.cs
+++ b/TobysBot.Discord.Audio/ShuffleSetting.cs
@@ -1,0 +1,5 @@
+namespace TobysBot.Discord.Audio;
+
+public abstract class ShuffleSetting {}
+public class EnabledShuffleSetting : ShuffleSetting {}
+public class DisabledShuffleSetting : ShuffleSetting {}

--- a/TobysBot.Discord.Client/Configuration/DiscordClientBuilder.cs
+++ b/TobysBot.Discord.Client/Configuration/DiscordClientBuilder.cs
@@ -32,7 +32,8 @@ public class DiscordClientBuilder
         Services.AddLavaNode(configureOptions);
         Services.AddSingleton<IAudioNode, LavalinkAudioNode>();
         Services.AddSingleton<IAudioSource, LavalinkAudioSource>();
-        Services.AddTransient<IQueue, MemoryQueue>();
+        Services.AddSingleton<IQueue, MemoryQueue>();
+        Services.AddTransient<ILyricsProvider, GeniusLyricsProvider>();
 
         Services.AddTransient<IDiscordReadyEventListener, LavalinkHostedService>();
         Services.AddTransient<IAudioEventListener, AudioEventListener>();

--- a/TobysBot.Discord.Client/TextCommands/CommandHandler.cs
+++ b/TobysBot.Discord.Client/TextCommands/CommandHandler.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Discord.Commands;
 using Discord.WebSocket;
+using Microsoft.Extensions.Configuration;
 
 namespace TobysBot.Discord.Client.TextCommands
 {
@@ -10,12 +11,14 @@ namespace TobysBot.Discord.Client.TextCommands
     {
         private readonly DiscordSocketClient _client;
         private readonly CommandService _commands;
+        private readonly IConfiguration _config;
         private readonly IServiceProvider _serviceProvider;
 
-        public CommandHandler(DiscordSocketClient client, CommandService commands, IServiceProvider serviceProvider)
+        public CommandHandler(DiscordSocketClient client, CommandService commands, IConfiguration config, IServiceProvider serviceProvider)
         {
             _client = client;
             _commands = commands;
+            _config = config;
             _serviceProvider = serviceProvider;
         }
 
@@ -35,7 +38,7 @@ namespace TobysBot.Discord.Client.TextCommands
 
             int argPos = 0;
 
-            if (!(message.HasCharPrefix('\\', ref argPos) ||
+            if (!(message.HasStringPrefix(_config.GetSection("Discord")["Prefix"], ref argPos) ||
                   message.HasMentionPrefix(_client.CurrentUser, ref argPos)) ||
                 message.Author.IsBot)
             {

--- a/TobysBot.Discord.Client/TextCommands/Extensions/Music/EmbedExtensions.cs
+++ b/TobysBot.Discord.Client/TextCommands/Extensions/Music/EmbedExtensions.cs
@@ -161,6 +161,36 @@ public static class EmbedExtensions
             .Build();
     }
 
+    public static Embed BuildLyricsEmbed(this EmbedBuilder embed, ITrack track, string lyrics)
+    {
+        var lines = lyrics.Split("\n");
+        
+        StringBuilder sb = new();
+
+        sb.AppendLine($"**{track.Title}**");
+        
+        foreach (var line in lines)
+        {
+            if (line.Contains('['))
+            {
+                sb.AppendLine();
+            }
+
+            if (sb.Length is > 1900 and < 2000)
+            {
+                sb.AppendLine("`...`");
+                break;
+            }
+
+            sb.AppendLine(line.Replace("[", "*").Replace("]", "*"));
+        }
+
+        return embed
+            .WithDescription(sb.ToString())
+            .WithContext(EmbedContext.Information)
+            .Build();
+    }
+
     public static Embed BuildTrackNotFoundEmbed(this EmbedBuilder embed, string query)
     {
         return embed

--- a/TobysBot.Discord.Client/TextCommands/Extensions/Music/EmbedExtensions.cs
+++ b/TobysBot.Discord.Client/TextCommands/Extensions/Music/EmbedExtensions.cs
@@ -32,9 +32,9 @@ public static class EmbedExtensions
                              $"{GetProgress(status.Position, status.Duration)} " +
                              $"`{status.Duration.ToTimeString()}` \n" +
                              $"{(status is PausedStatus ? "⏸" : "▶")}" +
-                             $"{(queueStatus.LoopEnabled is DisabledLoopSetting ? $" {status.ToString()}" : "")}" +
-                             $"{(queueStatus.LoopEnabled is TrackLoopSetting ? " 🔂 Looping the **current track**.": "")}" +
-                             $"{(queueStatus.LoopEnabled is QueueLoopSetting ? " 🔁 Looping the **queue**." : "")}" +
+                             $"{(queueStatus.LoopEnabled is TrackLoopSetting ? " 🔂": "")}" +
+                             $"{(queueStatus.LoopEnabled is QueueLoopSetting ? " 🔁" : "")}" +
+                             $"{(queueStatus.ShuffleEnabled is EnabledShuffleSetting ? " 🔀" : "")}" +
                              $"")
             .WithContext(EmbedContext.Information)
             .Build();
@@ -87,6 +87,12 @@ public static class EmbedExtensions
         {
             sb.AppendLine();
             sb.AppendLine("🔂 Looping the **current track**.");
+        }
+
+        if (queue.ShuffleEnabled is EnabledShuffleSetting)
+        {
+            sb.AppendLine();
+            sb.AppendLine("🔀 Shuffle mode is **enabled**.");
         }
         
         return embed

--- a/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
+++ b/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
@@ -277,6 +277,8 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
         {
             private readonly IAudioNode _node;
 
+            private IEmote ShuffleEmote => new Emoji("🔀");
+            
             public Shuffle(IAudioNode node) : base(node)
             {
                 _node = node;
@@ -313,6 +315,11 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
                 }
 
                 await _node.SetShuffleAsync(Context.Guild, new EnabledShuffleSetting());
+
+                await Context.Message.ReplyAsync(embed: new EmbedBuilder()
+                    .WithContext(EmbedContext.Action)
+                    .WithDescription("Shuffle mode is **enabled**.")
+                    .Build());
             }
 
             [Command("off")]
@@ -324,6 +331,11 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
                 }
 
                 await _node.SetShuffleAsync(Context.Guild, new DisabledShuffleSetting());
+
+                await Context.Message.ReplyAsync(embed: new EmbedBuilder()
+                    .WithContext(EmbedContext.Action)
+                    .WithDescription("Shuffle mode is **disabled**.")
+                    .Build());
             }
 
             [Command("once")]
@@ -335,6 +347,8 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
                 }
 
                 await _node.ShuffleAsync(Context.Guild);
+
+                await Context.Message.AddReactionAsync(ShuffleEmote);
             }
         }
 

--- a/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
+++ b/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
@@ -271,6 +271,72 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
                 await Context.Message.AddReactionAsync(SkipEmote);
             }
         }
+        
+        [Group("shuffle")]
+        public class Shuffle : VoiceModuleBase
+        {
+            private readonly IAudioNode _node;
+
+            public Shuffle(IAudioNode node) : base(node)
+            {
+                _node = node;
+            }
+
+            [Command]
+            public async Task ShuffleAsync()
+            {
+                if (!await EnsureUserInSameVoiceAsync())
+                {
+                    return;
+                }
+
+                var queue = await _node.GetQueueAsync(Context.Guild);
+
+                switch (queue.ShuffleEnabled)
+                {
+                    case EnabledShuffleSetting:
+                        await ShuffleOffAsync();
+                        break;
+                        
+                    case DisabledShuffleSetting:
+                        await ShuffleOnAsync();
+                        break;
+                }
+            }
+
+            [Command("on")]
+            public async Task ShuffleOnAsync()
+            {
+                if (!await EnsureUserInSameVoiceAsync())
+                {
+                    return;
+                }
+
+                await _node.SetShuffleAsync(Context.Guild, new EnabledShuffleSetting());
+            }
+
+            [Command("off")]
+            public async Task ShuffleOffAsync()
+            {
+                if (!await EnsureUserInSameVoiceAsync())
+                {
+                    return;
+                }
+
+                await _node.SetShuffleAsync(Context.Guild, new DisabledShuffleSetting());
+            }
+
+            [Command("once")]
+            public async Task ShuffleOnceAsync()
+            {
+                if (!await EnsureUserInSameVoiceAsync())
+                {
+                    return;
+                }
+
+                await _node.ShuffleAsync(Context.Guild);
+            }
+        }
 
         [Command("stop")]
         public async Task StopAsync()

--- a/TobysBot.Discord.Client/TextCommands/VoiceModuleBase.cs
+++ b/TobysBot.Discord.Client/TextCommands/VoiceModuleBase.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using TobysBot.Discord.Audio;
+using TobysBot.Discord.Client.TextCommands.Extensions.Music;
+
+namespace TobysBot.Discord.Client.TextCommands;
+
+public abstract class VoiceModuleBase : ModuleBase<SocketCommandContext>
+{
+    private readonly IAudioNode _node;
+
+    public VoiceModuleBase(IAudioNode node)
+    {
+        _node = node;
+    }
+    
+    protected bool IsUserInVoiceChannel(out IVoiceState voiceState)
+    {
+        voiceState = Context.User as IVoiceState;
+        return voiceState?.VoiceChannel is not null;
+    }
+
+    protected bool IsUserInSameVoiceChannel(out IVoiceState voiceState)
+    {
+        if (!IsUserInVoiceChannel(out voiceState))
+        {
+            return false;
+        }
+
+        return voiceState.VoiceChannel.Id == Context.Guild.CurrentUser.VoiceChannel?.Id;
+    }
+
+    protected async Task<bool> EnsureUserInVoiceAsync()
+    {
+        if (!IsUserInVoiceChannel(out IVoiceState voiceState))
+        {
+            await Context.Message.ReplyAsync(embed: new EmbedBuilder().BuildJoinVoiceEmbed());
+            return false;
+        }
+
+        await _node.JoinAsync(voiceState.VoiceChannel, Context.Channel as ITextChannel);
+
+        return true;
+    }
+
+    protected async Task<bool> EnsureUserInSameVoiceAsync()
+    {
+        if (!IsUserInSameVoiceChannel(out IVoiceState voiceState))
+        {
+            await Context.Message.ReplyAsync(embed: new EmbedBuilder().BuildJoinSameVoiceEmbed());
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/TobysBot.Discord/Startup.cs
+++ b/TobysBot.Discord/Startup.cs
@@ -27,6 +27,8 @@ namespace TobysBot.Discord
         {
             services.AddRazorPages();
 
+            var lavalinkConfig = Configuration.GetSection("Lavalink");
+
             services.AddDiscordClient(options =>
                 {
                     options.Token = Configuration.GetSection("Discord")["Token"];
@@ -35,9 +37,9 @@ namespace TobysBot.Discord
                 {
                     options.SelfDeaf = false;
 
-                    options.Hostname = "losingtime.dpaste.org";
-                    options.Port = 2124;
-                    options.Authorization = "SleepingOnTrains";
+                    options.Hostname = lavalinkConfig["Hostname"];
+                    options.Port = lavalinkConfig.GetValue<ushort>("Port");
+                    options.Authorization = lavalinkConfig["Authorization"];
 
                     options.LogSeverity = LogSeverity.Verbose;
                 });

--- a/TobysBot.Discord/appsettings.Development.json
+++ b/TobysBot.Discord/appsettings.Development.json
@@ -6,5 +6,9 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  
+  "Discord": {
+    "Prefix": "!"
   }
 }

--- a/TobysBot.Discord/appsettings.json
+++ b/TobysBot.Discord/appsettings.json
@@ -6,5 +6,15 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  
+  "Discord": {
+    "Prefix": "\\"
+  },
+  
+  "Lavalink": {
+    "Hostname": "losingtime.dpaste.org",
+    "Port": 2124,
+    "Authorization": "SleepingOnTrains"
+  }
 }


### PR DESCRIPTION
Added a bunch of new features and fixes.

## New Commands

- `\skip to [index]` - Jump to any track in the queue.
- `\seek [position]` - Jump to the specified position in the current track.
- `\lyrics` - Get lyrics for the current track.

### Shuffle

You can now shuffle the tracks in the queue, this can be done in two ways;

`\shuffle once` will randomise the order of tracks in the queue, any subsequently added tracks, or those which have already been played are unaffected.

`\shuffle` toggles shuffle mode, in this mode when a track finishes the next track is selected randomly, tracks added later will be affected.

## General Fixes

- Loop command has been improved so it can be directly changed between queue and track modes.
- The number of tracks that can be added from a playlist at once has been limited to 25, this is subject to change.