### PR TITLE
Update Skip

### DIFF
--- a/TobysBot.Discord.Audio/IAudioNode.cs
+++ b/TobysBot.Discord.Audio/IAudioNode.cs
@@ -64,7 +64,22 @@ namespace TobysBot.Discord.Audio
         /// </summary>
         /// <param name="guild"></param>
         /// <returns></returns>
-        Task<ITrack> SkipAsync(IGuild guild, int index = 0);
+        Task<ITrack> SkipAsync(IGuild guild);
+
+        /// <summary>
+        /// Skips to the previous track in the queue in the specified guild.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <returns></returns>
+        Task<ITrack> BackAsync(IGuild guild);
+
+        /// <summary>
+        /// Jumps to the specified track in the queue.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="track"></param>
+        /// <returns></returns>
+        Task<ITrack> JumpAsync(IGuild guild, int track);
 
         /// <summary>
         /// Clears the queue and stops player in the specified guild.

--- a/TobysBot.Discord.Audio/IQueue.cs
+++ b/TobysBot.Discord.Audio/IQueue.cs
@@ -27,8 +27,24 @@ namespace TobysBot.Discord.Audio
         /// Advances to the next track in the queue and returns the current track.
         /// </summary>
         /// <param name="guildId"></param>
+        /// <param name="ignoreTrackLoop"></param>
         /// <returns></returns>
-        Task<ITrack> AdvanceAsync(ulong guildId, int index = 0);
+        Task<ITrack> AdvanceAsync(ulong guildId, bool ignoreTrackLoop = false);
+
+        /// <summary>
+        /// Advances to the specified track and returns the current track.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        Task<ITrack> JumpAsync(ulong guild, int index);
+
+        /// <summary>
+        /// Advances to the previous track in the queue.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <returns></returns>
+        Task<ITrack> BackAsync(ulong guild);
 
         Task ProgressAsync(ulong guildId, TimeSpan position);
 

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
@@ -217,18 +217,11 @@ namespace TobysBot.Discord.Audio.Lavalink
             }
         }
 
-        public async Task<ITrack> SkipAsync(IGuild guild, int index = 0)
+        public async Task<ITrack> SkipAsync(IGuild guild)
         {
             var player = ThrowIfNoPlayer(guild);
 
-            var queue = await GetQueueAsync(guild);
-
-            if (queue.LoopEnabled is TrackLoopSetting)
-            {
-                await SetLoopAsync(guild, new DisabledLoopSetting());
-            }
-
-            ITrack nextTrack = await _queue.AdvanceAsync(guild.Id, index);
+            var nextTrack = await _queue.AdvanceAsync(guild.Id, true);
 
             if (nextTrack is null)
             {
@@ -240,6 +233,43 @@ namespace TobysBot.Discord.Audio.Lavalink
             }
             
             return nextTrack;
+        }
+
+        public async Task<ITrack> BackAsync(IGuild guild)
+        {
+            var player = ThrowIfNoPlayer(guild);
+
+            var previousTrack = await _queue.BackAsync(guild.Id);
+
+            if (previousTrack is null)
+            {
+                throw new Exception("No previous track to play.");
+            }
+
+            await player.PlayAsync(await _node.LoadTrackAsync(previousTrack));
+
+            return previousTrack;
+        }
+
+        public async Task<ITrack> JumpAsync(IGuild guild, int index)
+        {
+            var player = ThrowIfNoPlayer(guild);
+
+            if (index < 1)
+            {
+                throw new ArgumentException("Index must be > 1", nameof(index));
+            }
+            
+            var track = await _queue.JumpAsync(guild.Id, index);
+
+            if (track is null)
+            {
+                throw new Exception("Invalid track or index.");
+            }
+
+            await player.PlayAsync(await _node.LoadTrackAsync(track));
+
+            return track;
         }
 
         public async Task ClearAsync(IGuild guild)

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -33,15 +33,35 @@ namespace TobysBot.Discord.Audio.MemoryQueue
 
             return Task.FromResult<IQueueStatus>(queue);
         }
+        
+        public Task<ITrack> AdvanceAsync(ulong guild, bool ignoreTrackLoop = false)
+        {
+            if (!_queue.TryGetValue(guild, out var queue))
+            {
+                return Task.FromResult<ITrack>(null);
+            }
 
-        public Task<ITrack> AdvanceAsync(ulong guild, int index = 0)
+            return Task.FromResult(queue.Advance(ignoreTrackLoop));
+        }
+
+        public Task<ITrack> JumpAsync(ulong guild, int index)
         {
             if (!_queue.TryGetValue(guild, out var queue))
             {
                 return Task.FromResult<ITrack>(null);
             }
             
-            return Task.FromResult<ITrack>(queue.Advance(index-1));
+            return Task.FromResult(queue.Jump(index-1));
+        }
+
+        public Task<ITrack> BackAsync(ulong guild)
+        {
+            if (!_queue.TryGetValue(guild, out var queue))
+            {
+                return Task.FromResult<ITrack>(null);
+            }
+
+            return Task.FromResult(queue.Back());
         }
 
         public Task ProgressAsync(ulong guild, TimeSpan position)

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -35,28 +35,41 @@ namespace TobysBot.Discord.Audio.MemoryQueue
         {
             _currentPosition = position;
         }
-        
-        public ITrack Advance(int index)
+
+        public ITrack Jump(int index)
         {
-            if (index != -1)
+            if (index < 0 && index >= _tracks.Count)
             {
-                if (index < 0 && index >= _tracks.Count)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(index));
-                }
-                
-                var previous = _tracks.Take(index);
-                var current = _tracks[index];
-                var next = _tracks.Skip(index + 1);
-
-                _played = previous.ToList();
-                _currentTrack = current;
-                _queue = next.ToList();
-
-                return _currentTrack;
+                throw new ArgumentOutOfRangeException(nameof(index));
             }
-            
-            if (LoopEnabled is TrackLoopSetting)
+                
+            var previous = _tracks.Take(index);
+            var current = _tracks[index];
+            var next = _tracks.Skip(index + 1);
+
+            _played = previous.ToList();
+            _currentTrack = current;
+            _queue = next.ToList();
+
+            return _currentTrack;
+        }
+
+        public ITrack Back()
+        {
+            var previous = _played.SkipLast(1);
+            var current = _played.Last();
+            var next = _queue.Prepend(_currentTrack);
+
+            _played = previous.ToList();
+            _currentTrack = current;
+            _queue = next.ToList();
+
+            return _currentTrack;
+        }
+        
+        public ITrack Advance(bool ignoreTrackLoop)
+        {
+            if (!ignoreTrackLoop && LoopEnabled is TrackLoopSetting)
             {
                 return _currentTrack;
             }


### PR DESCRIPTION
- Reworked the queue backend to make it less confusing.
- Changed `skip to` command to `jump`, however is still available as an alias.
- Added new `back` command to play previous track.