### PR TITLE
Queue Management

### DIFF
--- a/TobysBot.Discord.Audio/IAudioNode.cs
+++ b/TobysBot.Discord.Audio/IAudioNode.cs
@@ -94,6 +94,34 @@ namespace TobysBot.Discord.Audio
         /// <param name="guild"></param>
         /// <returns></returns>
         Task StopAsync(IGuild guild);
+        
+        // Queue Management
+
+        /// <summary>
+        /// Removes the specified track from the queue.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="track"></param>
+        /// <returns></returns>
+        Task RemoveAsync(IGuild guild, int track);
+
+        /// <summary>
+        /// Removes the specified range of tracks from the queue.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="startTrack"></param>
+        /// <param name="endTrack"></param>
+        /// <returns></returns>
+        Task RemoveRangeAsync(IGuild guild, int startTrack, int endTrack);
+
+        /// <summary>
+        /// Moves the specified track to the new position.
+        /// </summary>
+        /// <param name="guild"></param>
+        /// <param name="track"></param>
+        /// <param name="newPos"></param>
+        /// <returns></returns>
+        Task MoveAsync(IGuild guild, int track, int newPos);
 
         // Status
 

--- a/TobysBot.Discord.Audio/IQueue.cs
+++ b/TobysBot.Discord.Audio/IQueue.cs
@@ -17,6 +17,32 @@ namespace TobysBot.Discord.Audio
         Task EnqueueAsync(ulong guildId, IEnumerable<ITrack> tracks, bool advanceToTracks = false);
 
         /// <summary>
+        /// Removes the specified track from the queue.
+        /// </summary>
+        /// <param name="guildId"></param>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        Task<(bool TrackChanged, ITrack CurrentTrack)> RemoveAsync(ulong guildId, int index);
+
+        /// <summary>
+        /// Removes the specified range of tracks from the queue.
+        /// </summary>
+        /// <param name="guildId"></param>
+        /// <param name="startIndex"></param>
+        /// <param name="endIndex"></param>
+        /// <returns></returns>
+        Task<(bool TrackChanged, ITrack CurrentTrack)> RemoveRangeAsync(ulong guildId, int startIndex, int endIndex);
+
+        /// <summary>
+        /// Moves the specified track to the specified position.
+        /// </summary>
+        /// <param name="guildId"></param>
+        /// <param name="index"></param>
+        /// <param name="destIndex"></param>
+        /// <returns></returns>
+        Task<(bool TrackChanged, ITrack CurrentTrack)> MoveAsync(ulong guildId, int index, int destIndex);
+        
+        /// <summary>
         /// Gets the queue for the specified guild.
         /// </summary>
         /// <param name="guildId"></param>

--- a/TobysBot.Discord.Audio/IQueueStatus.cs
+++ b/TobysBot.Discord.Audio/IQueueStatus.cs
@@ -4,9 +4,9 @@ namespace TobysBot.Discord.Audio
 {
     public interface IQueueStatus : IEnumerable<ITrack>
     {
-        IEnumerable<ITrack> Previous();
+        IEnumerable<ITrack> Previous { get; }
 
-        IEnumerable<ITrack> Next();
+        IEnumerable<ITrack> Next { get; }
 
         IActiveTrack CurrentTrack { get; }
         

--- a/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
+++ b/TobysBot.Discord.Audio/Lavalink/LavalinkAudioNode.cs
@@ -274,7 +274,7 @@ namespace TobysBot.Discord.Audio.Lavalink
 
         public async Task ClearAsync(IGuild guild)
         {
-            LavaPlayer player = ThrowIfNoPlayer(guild);
+            var player = ThrowIfNoPlayer(guild);
 
             await _queue.ClearAsync(guild.Id);
 
@@ -283,11 +283,47 @@ namespace TobysBot.Discord.Audio.Lavalink
 
         public async Task StopAsync(IGuild guild)
         {
-            LavaPlayer player = ThrowIfNoPlayer(guild);
+            var player = ThrowIfNoPlayer(guild);
 
             await _queue.ResetAsync(guild.Id);
             
             await player.StopAsync();
+        }
+
+        public async Task RemoveAsync(IGuild guild, int position)
+        {
+            var player = ThrowIfNoPlayer(guild);
+            
+            var (trackChanged, currentTrack) = await _queue.RemoveAsync(guild.Id, position);
+
+            if (trackChanged)
+            {
+                await player.PlayAsync(await _node.LoadTrackAsync(currentTrack));
+            }
+        }
+
+        public async Task RemoveRangeAsync(IGuild guild, int startTrack, int endTrack)
+        {
+            var player = ThrowIfNoPlayer(guild);
+            
+            var (trackChanged, currentTrack) = await _queue.RemoveRangeAsync(guild.Id, startTrack, endTrack);
+
+            if (trackChanged)
+            {
+                await player.PlayAsync(await _node.LoadTrackAsync(currentTrack));
+            }
+        }
+
+        public async Task MoveAsync(IGuild guild, int track, int newPos)
+        {
+            var player = ThrowIfNoPlayer(guild);
+            
+            var (trackChanged, currentTrack) = await _queue.MoveAsync(guild.Id, track, newPos);
+
+            if (trackChanged)
+            {
+                await player.PlayAsync(await _node.LoadTrackAsync(currentTrack));
+            }
         }
 
         public IPlayerStatus Status(IGuild guild)

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -31,7 +31,7 @@ namespace TobysBot.Discord.Audio.MemoryQueue
                 return Task.FromResult<IQueueStatus>(null);
             }
 
-            return Task.FromResult<IQueueStatus>(queue);
+            return Task.FromResult<IQueueStatus>(new MemoryQueueStatus(queue));
         }
         
         public Task<ITrack> AdvanceAsync(ulong guild, bool ignoreTrackLoop = false)

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueue.cs
@@ -24,6 +24,42 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             return Task.CompletedTask;
         }
 
+        public Task<(bool TrackChanged, ITrack CurrentTrack)> RemoveAsync(ulong guildId, int index)
+        {
+            if (!_queue.TryGetValue(guildId, out var queue))
+            {
+                throw new Exception("No queue for specified guild.");
+            }
+            
+            var changed = queue.Remove(index-1);
+            
+            return Task.FromResult<(bool TrackChanged, ITrack CurrentTrack)>((changed, queue.CurrentTrack));
+        }
+
+        public Task<(bool TrackChanged, ITrack CurrentTrack)> RemoveRangeAsync(ulong guildId, int startIndex, int endIndex)
+        {
+            if (!_queue.TryGetValue(guildId, out var queue))
+            {
+                throw new Exception("No queue for specified guild.");
+            }
+            
+            var changed = queue.RemoveRange(startIndex-1, endIndex-1);
+            
+            return Task.FromResult<(bool TrackChanged, ITrack CurrentTrack)>((changed, queue.CurrentTrack));
+        }
+
+        public Task<(bool TrackChanged, ITrack CurrentTrack)> MoveAsync(ulong guildId, int index, int destIndex)
+        {
+            if (!_queue.TryGetValue(guildId, out var queue))
+            {
+                throw new Exception("No queue for specified guild.");
+            }
+            
+            var changed = queue.Move(index-1, destIndex-1);
+
+            return Task.FromResult<(bool TrackChanged, ITrack CurrentTrack)>((changed, queue.CurrentTrack));
+        }
+
         public Task<IQueueStatus> GetAsync(ulong guild)
         {
             if (!_queue.TryGetValue(guild, out var queue))

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryQueueStatus.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryQueueStatus.cs
@@ -1,0 +1,39 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TobysBot.Discord.Audio.MemoryQueue;
+
+public class MemoryQueueStatus : IQueueStatus
+{
+    private IEnumerable<ITrack> _tracks;
+
+    public MemoryQueueStatus(MemoryTrackCollection tracks)
+    {
+        _tracks = tracks.ToList();
+
+        Previous = tracks.Played;
+        CurrentTrack = tracks.CurrentTrack;
+        Next = tracks.Queue;
+
+        LoopEnabled = tracks.LoopEnabled;
+        ShuffleEnabled = tracks.ShuffleEnabled;
+    }
+
+    public IEnumerable<ITrack> Previous { get; }
+    public IEnumerable<ITrack> Next { get; }
+    public IActiveTrack CurrentTrack { get; }
+    
+    public LoopSetting LoopEnabled { get; }
+    public ShuffleSetting ShuffleEnabled { get; }
+
+    public IEnumerator<ITrack> GetEnumerator()
+    {
+        return _tracks.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -104,7 +104,7 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             
             _tracks.RemoveAt(index);
 
-            return track == CurrentTrack;
+            return track.Id != CurrentTrack.Id;
         }
 
         public bool RemoveRange(int startIndex, int endIndex)
@@ -120,19 +120,30 @@ namespace TobysBot.Discord.Audio.MemoryQueue
             
             _tracks.RemoveRange(startIndex, count);
 
-            return track == CurrentTrack;
+            return track.Id != CurrentTrack.Id;
         }
 
         public bool Move(int index, int destIndex)
         {
             var currentTrack = CurrentTrack;
             
+            if (index < _currentIndex)
+            {
+                _currentIndex--;
+            }
+
+            if (destIndex <= _currentIndex)
+            {
+                _currentIndex++;
+            }
+            
             var track = _tracks[index];
+            
             
             _tracks.RemoveAt(index);
             _tracks.Insert(destIndex, track);
 
-            return currentTrack == CurrentTrack;
+            return currentTrack.Id != CurrentTrack.Id;
         }
         
         public void Reset()

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -111,12 +111,17 @@ namespace TobysBot.Discord.Audio.MemoryQueue
         {
             var track = CurrentTrack;
             
-            if (startIndex < _currentIndex || endIndex > _currentIndex)
+            if (startIndex < _currentIndex && endIndex >= _currentIndex)
             {
                 _currentIndex = startIndex;
             }
             
-            var count = endIndex - startIndex;
+            var count = endIndex - startIndex + 1;
+
+            if (startIndex < _currentIndex && endIndex <= _currentIndex)
+            {
+                _currentIndex -= count;
+            }
             
             _tracks.RemoveRange(startIndex, count);
 

--- a/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
+++ b/TobysBot.Discord.Audio/MemoryQueue/MemoryTrackCollection.cs
@@ -93,6 +93,48 @@ namespace TobysBot.Discord.Audio.MemoryQueue
                 select new MemoryTrack(track));
         }
 
+        public bool Remove(int index)
+        {
+            var track = CurrentTrack;
+            
+            if (index < _currentIndex)
+            {
+                _currentIndex--;
+            }
+            
+            _tracks.RemoveAt(index);
+
+            return track == CurrentTrack;
+        }
+
+        public bool RemoveRange(int startIndex, int endIndex)
+        {
+            var track = CurrentTrack;
+            
+            if (startIndex < _currentIndex || endIndex > _currentIndex)
+            {
+                _currentIndex = startIndex;
+            }
+            
+            var count = endIndex - startIndex;
+            
+            _tracks.RemoveRange(startIndex, count);
+
+            return track == CurrentTrack;
+        }
+
+        public bool Move(int index, int destIndex)
+        {
+            var currentTrack = CurrentTrack;
+            
+            var track = _tracks[index];
+            
+            _tracks.RemoveAt(index);
+            _tracks.Insert(destIndex, track);
+
+            return currentTrack == CurrentTrack;
+        }
+        
         public void Reset()
         {
             _currentIndex = 0;
@@ -111,7 +153,7 @@ namespace TobysBot.Discord.Audio.MemoryQueue
                 (queue[k], queue[n]) = (queue[n], queue[k]);
             }
 
-            _tracks = _tracks.Take(_currentIndex).Concat(queue).ToList();
+            _tracks = _tracks.Take(_currentIndex + 1).Concat(queue).ToList();
         }
         
         public IEnumerator<ITrack> GetEnumerator()

--- a/TobysBot.Discord.Client/TextCommands/Extensions/EmbedExtensions.Music.cs
+++ b/TobysBot.Discord.Client/TextCommands/Extensions/EmbedExtensions.Music.cs
@@ -43,8 +43,8 @@ public static partial class EmbedExtensions
     
     public static Embed BuildQueueEmbed(this EmbedBuilder embed, IQueueStatus queue, ITrackStatus trackStatus)
     {
-        var previous = new Queue<ITrack>(queue.Previous().Reverse());
-        var next = new Queue<ITrack>(queue.Next());
+        var previous = new Queue<ITrack>(queue.Previous.Reverse());
+        var next = new Queue<ITrack>(queue.Next);
         var current = trackStatus?.CurrentTrack;
         
         var sb = new StringBuilder();

--- a/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
+++ b/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
@@ -380,7 +380,7 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
 
             var queue = await _node.GetQueueAsync(Context.Guild);
 
-            if (!queue.Previous().Any())
+            if (!queue.Previous.Any())
             {
                 await Context.Message.ReplyAsync(embed: new EmbedBuilder()
                     .WithContext(EmbedContext.Error)
@@ -460,7 +460,7 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
                 return;
             }
             
-            if (queue.CurrentTrack is not null && !queue.Next().Any())
+            if (queue.CurrentTrack is not null && !queue.Next.Any())
             {
                 await _node.SetLoopAsync(Context.Guild, new TrackLoopSetting());
                 await Context.Message.ReplyAsync(embed: new EmbedBuilder().BuildLoopTrackEmbed());

--- a/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
+++ b/TobysBot.Discord.Client/TextCommands/Modules/MusicModule.cs
@@ -619,6 +619,51 @@ namespace TobysBot.Discord.Client.TextCommands.Modules
             await Context.Message.AddReactionAsync(ShuffleEmote);
         }
         
+        // Queue Management
+
+        [Command("move")]
+        [Alias("mv")]
+        [Summary("Move the specified track to the specified position.")]
+        public async Task MoveAsync(int track, int position)
+        {
+            if (!await EnsureUserInSameVoiceAsync())
+            {
+                return;
+            }
+
+            var queue = await _node.GetQueueAsync(Context.Guild);
+
+            if (queue is null)
+            {
+                await Context.Message.ReplyAsync(embed: new EmbedBuilder().BuildNotPlayingEmbed());
+                return;
+            }
+            
+            if (track > queue.Count() || track < 1)
+            {
+                await Context.Message.ReplyAsync(embed: new EmbedBuilder()
+                    .WithContext(EmbedContext.Error)
+                    .WithDescription("No track at that position in the queue.")
+                    .Build());
+                
+                return;
+            }
+
+            if (position > queue.Count() || position < 1)
+            {
+                await Context.Message.ReplyAsync(embed: new EmbedBuilder()
+                    .WithContext(EmbedContext.Error)
+                    .WithDescription("The queue is not that long.")
+                    .Build());
+                
+                return;
+            }
+
+            await _node.MoveAsync(Context.Guild, track, position);
+
+            await ReplyAsync("moved");
+        }
+
         // Information
 
         [Command("np")]


### PR DESCRIPTION
Added new commands to allow users to manage the existing tracks in the queue.

- `\move` moves a track to a new position.
- `\remove` removes a track.
- `\remove range` removes a range of tracks.

The backend queue logic has also been changed to be potentially more reliable.