### PR TITLE
Timestamp Loop

### DIFF
--- a/src/TobysBot.Music/Commands/MusicModule.cs
+++ b/src/TobysBot.Music/Commands/MusicModule.cs
@@ -400,7 +400,7 @@ public class MusicModule : VoiceCommandModuleBase
     [Summary("Toggles looping the current track.")]
     [RequireContext(ContextType.Guild, ErrorMessage = GuildRequiredErrorMessage)]
     [CheckVoice(sameChannel: SameChannel.Required)]
-    public Task LoopTrackAsync() => LoopAsync(new TrackLoopSetting());
+    public Task LoopTrackAsync(TimeSpan? start = null, TimeSpan? end = null) => LoopAsync(new TrackLoopSetting(start, end));
 
     [Command("loop queue")]
     [Summary("Toggles looping the queue.")]
@@ -419,7 +419,8 @@ public class MusicModule : VoiceCommandModuleBase
     [Summary("Toggles looping.")]
     [RequireContext(ContextType.Guild, ErrorMessage = GuildRequiredErrorMessage)]
     [CheckVoice(sameChannel: SameChannel.Required)]
-    public Task LoopToggleAsync() => LoopAsync();
+    public Task LoopToggleAsync(TimeSpan? start = null, TimeSpan? end = null) => 
+        start.HasValue || end.HasValue ? LoopTrackAsync(start, end) : LoopAsync();
 
     private async Task LoopAsync(ILoopSetting? setting = null)
     {
@@ -445,12 +446,12 @@ public class MusicModule : VoiceCommandModuleBase
 
             case TrackLoopSetting:
             case null when queue.CurrentTrack is not null && !queue.Next.Any():
-                setting = new TrackLoopSetting();
+                setting ??= new TrackLoopSetting();
                 break;
 
             case QueueLoopSetting:
             case null:
-                setting = new QueueLoopSetting();
+                setting ??= new QueueLoopSetting();
                 break;
 
             default:

--- a/src/TobysBot.Music/Commands/MusicModule.cs
+++ b/src/TobysBot.Music/Commands/MusicModule.cs
@@ -206,7 +206,7 @@ public class MusicModule : VoiceCommandModuleBase
     [CheckVoice(sameChannel: SameChannel.Required)]
     public async Task SeekAsync(
         [Summary("Timestamp in the current track to skip to.")]
-        string timestamp)
+        TimeSpan timestamp)
     {
         var track = await _music.GetTrackAsync(Context.Guild!);
 
@@ -219,18 +219,7 @@ public class MusicModule : VoiceCommandModuleBase
             return;
         }
 
-        string[] formats = { @"%h\:%m\:%s", @"%m\:%s" };
-
-        if (!TimeSpan.TryParseExact(timestamp, formats, null, TimeSpanStyles.None, out var timeSpan))
-        {
-            await Response.ReplyAsync(embed: _embeds.Builder()
-                .WithCannotParseTimestampError()
-                .Build());
-
-            return;
-        }
-
-        if (timeSpan > track.Duration)
+        if (timestamp > track.Duration)
         {
             await Response.ReplyAsync(embed: _embeds.Builder()
                 .WithTimestampTooLongError()
@@ -239,7 +228,7 @@ public class MusicModule : VoiceCommandModuleBase
             return;
         }
 
-        await _music.SeekAsync(Context.Guild!, timeSpan);
+        await _music.SeekAsync(Context.Guild!, timestamp);
 
         await Response.ReactAsync(FastForwardEmote);
     }

--- a/src/TobysBot.Music/Events/AutoplayEventHandler.cs
+++ b/src/TobysBot.Music/Events/AutoplayEventHandler.cs
@@ -26,13 +26,19 @@ public class AutoplayEventHandler : IEventHandler<SoundEndedEventArgs>
             return;
         }
 
-        var track = _queues[args.Guild.Id].Advance(false);
+        var queue = _queues[args.Guild.Id];
+        
+        var track = queue.Advance(false);
 
         if (track is null)
         {
             return;
         }
 
-        await _voice.PlayAsync(args.Guild, await _audio.LoadAudioAsync(track), TimeSpan.Zero);
+        var startTime = queue.LoopEnabled is TrackLoopSetting { Start: not null } loop
+            ? loop.Start.Value
+            : TimeSpan.Zero;
+        
+        await _voice.PlayAsync(args.Guild, await _audio.LoadAudioAsync(track), startTime);
     }
 }

--- a/src/TobysBot.Music/LoopSetting.cs
+++ b/src/TobysBot.Music/LoopSetting.cs
@@ -18,7 +18,23 @@ public class EnabledLoopSetting : ILoopSetting { }
 /// <summary>
 /// Looping is enabled for the current track.
 /// </summary>
-public class TrackLoopSetting : EnabledLoopSetting { }
+public class TrackLoopSetting : EnabledLoopSetting
+{ 
+    public TrackLoopSetting()
+    {
+        Start = null;
+        End = null;
+    }
+    
+    public TrackLoopSetting(TimeSpan? start = null, TimeSpan? end = null)
+    {
+        Start = start;
+        End = end;
+    }
+    
+    public TimeSpan? Start { get; }
+    public TimeSpan? End { get; }
+}
 
 /// <summary>
 /// Looping is enabled for the queue.

--- a/src/TobysBot.Music/MemoryQueue/MemoryMusicService.cs
+++ b/src/TobysBot.Music/MemoryQueue/MemoryMusicService.cs
@@ -224,11 +224,17 @@ public class MemoryMusicService : IMusicService
         return Task.CompletedTask;
     }
 
-    public Task SetLoopAsync(IGuild guild, ILoopSetting setting)
+    public async Task SetLoopAsync(IGuild guild, ILoopSetting setting)
     {
-        _queues[guild.Id].LoopEnabled = setting;
+        var queue = _queues[guild.Id];
         
-        return Task.CompletedTask;
+        queue.LoopEnabled = setting;
+
+        if (setting is TrackLoopSetting track &&
+            (queue.CurrentTrack?.Position < track.Start || queue.CurrentTrack?.Position > track.End))
+        {
+            await _voice.SeekAsync(guild, track.Start ?? TimeSpan.Zero);
+        }
     }
 
     public Task SetShuffleAsync(IGuild guild, bool shuffle)

--- a/src/TobysBot/Commands/CustomCommandService.cs
+++ b/src/TobysBot/Commands/CustomCommandService.cs
@@ -3,6 +3,7 @@ using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.Options;
 using TobysBot.Commands.Builders;
+using TobysBot.Commands.TypeReaders;
 using TobysBot.Configuration;
 using TobysBot.Extensions;
 
@@ -40,6 +41,8 @@ public class CustomCommandService : ICommandService
     
     public async Task InstallCommandsAsync()
     {
+        _commandService.AddTypeReader<TimeSpan>(new TimeSpanTypeReader());
+        
         foreach (var module in _registeredModules)
         {
             await _commandService.AddModuleAsync(module.ModuleType, _services);

--- a/src/TobysBot/Commands/TypeReaders/TimeSpanTypeReader.cs
+++ b/src/TobysBot/Commands/TypeReaders/TimeSpanTypeReader.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+using Discord.Commands;
+
+namespace TobysBot.Commands.TypeReaders;
+
+public class TimeSpanTypeReader : TypeReader
+{
+    public override Task<TypeReaderResult> ReadAsync(ICommandContext context, string input, IServiceProvider services)
+    {
+        string[] formats = { @"%h\:%m\:%s", @"%m\:%s" };
+
+        if (!TimeSpan.TryParseExact(input, formats, null, TimeSpanStyles.None, out var result))
+        {
+            return Task.FromResult(TypeReaderResult.FromError(CommandError.ParseFailed,
+                "Could not parse that timestamp."));
+        }
+
+        return Task.FromResult(TypeReaderResult.FromSuccess(result));
+    }
+}


### PR DESCRIPTION
Added the ability to loop the current track between two timestamps. For example `\loop 2:00 5:00`. Can also be used with only one argument to signify the start of the loop with the track continuing to the end.